### PR TITLE
Clone vanilla behaviour

### DIFF
--- a/src/main/java/lilypad/bukkit/connect/login/LoginListener.java
+++ b/src/main/java/lilypad/bukkit/connect/login/LoginListener.java
@@ -98,7 +98,7 @@ public class LoginListener implements Listener {
 			} else {
 				event.disallow(PlayerLoginEvent.Result.KICK_BANNED, banMessage.toString());
 			}
-		} else if (this.connectPlugin.getServer().hasWhitelist() && !player.isWhitelisted()) {
+		} else if (this.connectPlugin.getServer().hasWhitelist() && !player.isWhitelisted() && !player.isOp()) {
 			event.disallow(PlayerLoginEvent.Result.KICK_WHITELIST, this.connectPlugin.getSpigotHook().isSpigot() ? this.connectPlugin.getSpigotHook().getWhitelistMessage() : "You are not white-listed on this server!");
 		} else if (this.connectPlugin.getServer().getIPBans().contains(payload.getRealIp())) {
 			BanList banList = this.connectPlugin.getServer().getBanList(BanList.Type.IP);


### PR DESCRIPTION
This allows ops to join even when they're not whitelisted - cloning vanilla/default Spigot behaviour
