### PR TITLE
Fix NPE

### DIFF
--- a/src/main/java/lilypad/bukkit/connect/login/LoginNettyInjectHandler.java
+++ b/src/main/java/lilypad/bukkit/connect/login/LoginNettyInjectHandler.java
@@ -176,7 +176,6 @@ public class LoginNettyInjectHandler implements NettyInjectHandler {
 				if (this.connectPlugin.getServer().getPluginManager().getPlugin("ProtocolSupport") == null) {
 					throw exception;
 				}
-				Object packetListener = LoginListenerProxy.getPacketListenerField().get(networkManager);
 				GameProfile profile = ReflectionUtils.getPrivateField(object.getClass(), object, GameProfile.class, "a");
 				LoginPayload payload = payloadCache.getByName(profile.getName());
 				LoginPayload.Property[] payloadProperties = payload.getProperties();
@@ -188,7 +187,11 @@ public class LoginNettyInjectHandler implements NettyInjectHandler {
 				}
 				ReflectionUtils.setFinalField(networkManager.getClass(), networkManager, "spoofedUUID", payload.getUUID());
 				ReflectionUtils.setFinalField(networkManager.getClass(), networkManager, "spoofedProfile", properties);
-				ReflectionUtils.setFinalField(packetListener.getClass().getSuperclass(), packetListener, "isOnlineMode", false);
+				if (LoginListenerProxy.getPacketListenerField() != null) {
+					Object packetListener = LoginListenerProxy.getPacketListenerField().get(networkManager);
+					ReflectionUtils.setFinalField(packetListener.getClass().getSuperclass(), packetListener, "isOnlineMode", false);
+					return;
+				}
 			}
 		} catch (Exception exception) {
 			exception.printStackTrace();


### PR DESCRIPTION
If LoginListenerProxy.get() fails with an exception on the first login, therefore invoking this catch block, packetListenerField in LoginListenerProxy will be null, therefore causing a NullPointerException to be thrown when calling LoginListenerProxy.getPacketListenerField().get() below. This causes some very strange behaviour indeed, as the server seems to get the incorrect UUID for the player but allows the login, therefore loading the wrong players data. Relevant stack trace: https://gist.github.com/harrydevane/6be31947828311ef5a784dc2e1320669

Note: This seems to only be an issue when running ProtocolSupport on 1.8